### PR TITLE
fix: missing export for services in web components

### DIFF
--- a/packages/web/projects/web-components/src/services/index.ts
+++ b/packages/web/projects/web-components/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './confirmation.service';
+export * from './message.service';


### PR DESCRIPTION
Tava faltando o index.ts para exportar os modulos de serviços no web-components impossibilitando seu uso.