### PR TITLE
ci: fix storybook deps install with legacy param

### DIFF
--- a/.github/workflows/build-web-storybook.yml
+++ b/.github/workflows/build-web-storybook.yml
@@ -22,7 +22,7 @@ jobs:
           node generateJson.mjs
           cd ../../packages/web
           npm i -g npm@8
-          npm i --quiet
+          npm i --quiet --legacy-peer-deps
           npm run build-storybook
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
Adicionando `--legacy-peer-deps` na instalação das dependências para a build do Storybook.