### PR TITLE
ci: add legacy deps flag to web components workflow

### DIFF
--- a/.github/workflows/web-components.yml
+++ b/.github/workflows/web-components.yml
@@ -29,7 +29,7 @@ jobs:
           rm -rf package-lock.json
           npm i -g npm@8
           cd packages/web
-          npm ci --quiet
+          npm ci --quiet --legacy-peer-deps
 
       - name: Configure git
         run: |


### PR DESCRIPTION
Adicionando --legacy-peer-deps na instalação das dependências para a build da lib `@freud-ds/web-components`.