### PR TITLE
fix(freud-button): block pointer event when disabled or loading

### DIFF
--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 
 type buttonSizes = 'sm' | 'md' | 'lg';
 type buttonColors = 'primary' | 'secondary' | 'ghost';
@@ -27,6 +27,12 @@ type buttonColors = 'primary' | 'secondary' | 'ghost';
   }
 })
 export class FreudButtonComponent {
+  @HostBinding('style.pointer-events') get pEvents(): string {
+    if (this.disabled || this.loading) {
+      return 'none';
+    }
+    return 'auto';
+  }
 
   @Input() size: buttonSizes = 'md';
   @Input() color: buttonColors = 'primary';


### PR DESCRIPTION
Hoje ao clicar em um botão, mesmo desabilitado ou em carregamento o evento de click não é bloqueado

`<freud-button (click)="meuMétodo()" [disabled]="true" [loading]="true"></freud-button>
`

no exemplo acima o **meuMétodo()** não deveria ser chamado

Ref da correção:
https://stackoverflow.com/a/60692083