### PR TITLE
Tplat 225

### DIFF
--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
@@ -97,8 +97,6 @@
   .p-button {
     font-size: $font-size-xxs;
     padding: 0 $spacing-size-nano;
-    padding-left: 8px;
-    padding-right: 8px;
     height: 32px;
     &.p-button-icon-only {
       padding: 0 3px;
@@ -109,8 +107,6 @@
 .freud-btn-size-medium {
   .p-button {
     padding: 0 $spacing-size-xxxs;
-    padding-left: 16px;
-    padding-right: 16px;
     height: 40px;
     &.p-button-icon-only {
       padding: 0 7px;
@@ -120,9 +116,7 @@
 
 .freud-btn-size-large {
   .p-button {
-    padding: 0 $spacing-size-xxs;
-    padding-left: 16px;
-    padding-right: 16px;
+    padding: 0 $spacing-size-xxxs;
     height: 48px;
     &.p-button-icon-only {
       padding: 0 11px;

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
@@ -1,10 +1,10 @@
-@import '../../../../../../../tokens/dist/style/scss/variables';
-@import '../../../../scss/typography';
+@import "../../../../../../../tokens/dist/style/scss/variables";
+@import "../../../../scss/typography";
 
 .freud-btn:not(.freud-btn-bgcolor) {
   &.freud-btn-color-primary {
     .p-button {
-      background-color:  $brand-color-pure;
+      background-color: $brand-color-pure;
       border-color: $brand-color-pure;
       color: $neutral-color-white;
     }
@@ -75,10 +75,9 @@
   }
 }
 
-
 .freud-btn .p-button {
   font-family: $font-family-base;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: $border-radius-md;
@@ -93,7 +92,6 @@
     width: auto;
   }
 }
-
 
 .freud-btn-size-small {
   .p-button {
@@ -135,3 +133,28 @@
 .button-content:not(:empty) + .p-button-icon {
   margin-left: $spacing-size-xxxs;
 }
+
+.p-button .p-button-icon-left {
+  &.p-bnt-size-small {
+    margin-right: 8px;
+  }
+  &.p-bnt-size-medium {
+    margin-right: 16px;
+  }
+  &.p-bnt-size-large {
+    margin-right: 16px;
+  }
+}
+
+.p-button .p-button-icon-right {
+  &.p-bnt-size-small {
+    margin-left: 8px;
+  }
+  &.p-bnt-size-medium {
+    margin-left: 16px;
+  }
+  &.p-bnt-size-large {
+    margin-left: 16px;
+  }
+}
+

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
@@ -99,6 +99,8 @@
   .p-button {
     font-size: $font-size-xxs;
     padding: 0 $spacing-size-nano;
+    padding-left: 8px;
+    padding-right: 8px;
     height: 32px;
     &.p-button-icon-only {
       padding: 0 3px;
@@ -109,6 +111,8 @@
 .freud-btn-size-medium {
   .p-button {
     padding: 0 $spacing-size-xxxs;
+    padding-left: 16px;
+    padding-right: 16px;
     height: 40px;
     &.p-button-icon-only {
       padding: 0 7px;
@@ -119,6 +123,8 @@
 .freud-btn-size-large {
   .p-button {
     padding: 0 $spacing-size-xxs;
+    padding-left: 16px;
+    padding-right: 16px;
     height: 48px;
     &.p-button-icon-only {
       padding: 0 11px;

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -8,7 +8,7 @@ import {
 type buttonSizes = 'sm' | 'md' | 'lg';
 type buttonColors = 'primary' | 'secondary' | 'ghost';
 
-type iconPositions = 'left' | 'right';
+type iconPos = 'left' | 'right';
 
 @Component({
   selector: 'freud-button',
@@ -56,5 +56,5 @@ export class FreudButtonComponent {
   @Input() loading = false;
   @Input() icon: string = '';
   @Input() label: string = '';
-  @Input() iconPos = 'left';
+  @Input() iconPos: iconPos = 'left';
 }

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ViewEncapsulation,
+} from '@angular/core';
 
 type buttonSizes = 'sm' | 'md' | 'lg';
 type buttonColors = 'primary' | 'secondary' | 'ghost';
@@ -8,8 +13,15 @@ type buttonColors = 'primary' | 'secondary' | 'ghost';
   styleUrls: ['./button.component.scss'],
   encapsulation: ViewEncapsulation.None,
   template: `
-    <p-button [disabled]="disabled" [loading]="loading" [icon]="icon" [type]="type">
-      <div class="button-content"><ng-content></ng-content></div>
+    <p-button
+      [disabled]="disabled"
+      [loading]="loading"
+      [icon]="icon"
+      [type]="type"
+      [label]="label"
+      [iconPos]="iconPos"
+    >
+      <div class="button-content" *ngIf="!label"><ng-content></ng-content></div>
     </p-button>
   `,
   host: {
@@ -24,7 +36,7 @@ type buttonColors = 'primary' | 'secondary' | 'ghost';
     '[class.freud-btn-size-small]': `size === 'sm'`,
     '[class.freud-btn-size-medium]': `size === 'md'`,
     '[class.freud-btn-size-large]': `size === 'lg'`,
-  }
+  },
 })
 export class FreudButtonComponent {
   @HostBinding('style.pointer-events') get pEvents(): string {
@@ -41,5 +53,6 @@ export class FreudButtonComponent {
   @Input() type!: string;
   @Input() loading = false;
   @Input() icon!: string;
-
+  @Input() label: string = '';
+  @Input() iconPos: 'left' | 'right' = 'left';
 }

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -52,7 +52,7 @@ export class FreudButtonComponent {
   @Input() disabled = false;
   @Input() type!: string;
   @Input() loading = false;
-  @Input() icon!: string;
+  @Input() icon: string = '';
   @Input() label: string = '';
   @Input() iconPos: 'left' | 'right' = 'left';
 }

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -8,6 +8,8 @@ import {
 type buttonSizes = 'sm' | 'md' | 'lg';
 type buttonColors = 'primary' | 'secondary' | 'ghost';
 
+type iconPositions = 'left' | 'right';
+
 @Component({
   selector: 'freud-button',
   styleUrls: ['./button.component.scss'],
@@ -54,5 +56,5 @@ export class FreudButtonComponent {
   @Input() loading = false;
   @Input() icon: string = '';
   @Input() label: string = '';
-  @Input() iconPos: 'left' | 'right' = 'left';
+  @Input() iconPos = 'left';
 }

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -1,96 +1,111 @@
 import { Story } from '@storybook/angular';
 import { FreudButtonComponent } from '@freud-ds/web-components';
 
-const templateHTML = `
-    <freud-button
-      [color]="color"
-      [bgColor]="bgColor"
-      [size]="size"
-      [disabled]="disabled"
-      [loading]="loading"
-      [icon]="icon"
-      >{{label}}</freud-button>
-`;
+// Button Test
+const TemplateTest: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
+  props: { ...args },
+  template: `<freud-button [color]="color" [bgColor]="bgColor" [size]="size" [disabled]="disabled" 
+[loading]="loading" [icon]="icon" [label]="label" [iconPos]="iconPos"></freud-button>`,
+});
 
-// Collors
-const Template: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTML.replace('{{label}}', 'Button {{color}}'),
-});
-export const Primary = Template.bind({});
-Primary.args = {
-  color: 'primary',
-};
-export const Secondary = Template.bind({});
-Secondary.args = {
-  color: 'secondary'
-};
-export const Ghost = Template.bind({});
-Ghost.args = {
-  color: 'ghost'
-};
-// Disabled
-const TemplateDisabled: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTML.replace('{{label}}', 'Disabled'),
-});
-export const Disabled = TemplateDisabled.bind({});
-Disabled.args = {
-  disabled: true
+export const ButtonTest = TemplateTest.bind({});
+ButtonTest.args = {
+  label: 'Teste'
 }
 
+// Theme
+export const Primary = () => {
+  return {
+    template: `<freud-button [label]="'Button primary'"></freud-button>`,
+  };
+};
+
+export const Secondary = () => {
+  return {
+    template: `<freud-button [color]="'secundary'" [label]="'Button secondary'"></freud-button>`,
+  };
+};
+
+export const Ghost = () => {
+  return {
+    template: `<freud-button [color]="'ghost'" [label]="'Button ghost'"></freud-button>`,
+  };
+};
+
+// Background
+export const BGColorPrimary = () => {
+  return {
+    template: `<freud-button [bgColor]="true" [label]="'ButtonBG primary'"></freud-button>`,
+  };
+};
+
+export const BGColorSecondary = () => {
+  return {
+    template: `<freud-button [bgColor]="true" [color]="'secondary'" [label]="'ButtonBG secondary'"></freud-button>`,
+  };
+};
+
+export const BGColorGhost = () => {
+  return {
+    template: `<freud-button [bgColor]="true" [color]="'ghost'" [label]="'ButtonBG ghost'"></freud-button>`,
+  };
+};
+
+// Disabled
+export const Disabled = () => {
+  return {
+    template: `<freud-button [disabled]="true" [label]="'Button disabled'"></freud-button>`,
+  };BGColorGhost
+};
+
 // Loading
-const TemplateLoading: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTML.replace('{{label}}', 'Button'),
-});
-export const Loading = TemplateLoading.bind({});
-Loading.args = {
-  loading: true,
-  bgColor: false
+export const Loading = () => {
+  return {
+    template: `<freud-button [loading]="true" [bgColor]="false" [label]="'Button loading'" [iconPos]="'right'"></freud-button>`,
+  };
 }
 
 // Sizes
+export const SizeLg = () => {
+  return {
+    template: `<freud-button [bgColor]="bgColor" [size]="'lg'" [label]="'Button large'"></freud-button>`,
+  };
+};
 
-const templateHTMLSize = `
-    <div style="display: flex;gap: 16px;align-items: center">
-      <freud-button [bgColor]="bgColor" [color]="color" [size]="'sm'">Button sm</freud-button>
-      <freud-button [bgColor]="bgColor" [size]="'md'">Button md</freud-button>
-      <freud-button [bgColor]="bgColor" [size]="'lg'">Button lg</freud-button>
-    </div>
-`;
-const TemplateSize: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTMLSize,
-});
-export const Size = TemplateSize.bind({});
+export const SizeMd = () => {
+  return {
+    template: `<freud-button [bgColor]="bgColor" [size]="'md'" [label]="'Button medium'"></freud-button>`,
+  };
+};
 
-// Background
-const templateHTMLBgColor = `
-    <div style="display: flex;gap: 16px;align-items: center">
-      <freud-button [bgColor]="true" [color]="'primary'">Button primary</freud-button>
-      <freud-button [bgColor]="true" [color]="'secondary'">Button secondary</freud-button>
-      <freud-button [bgColor]="true" [color]="'ghost'">Button ghost</freud-button>
-    </div>
-`;
-const TemplateBGColor: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTMLBgColor,
-});
-export const BGColor = TemplateBGColor.bind({});
+export const SizeSm = () => {
+  return {
+    template: `<freud-button [bgColor]="bgColor" [size]="'sm'" [label]="'Button small'"></freud-button>`,
+  };
+};
 
-const TemplateIcon: Story<FreudButtonComponent> = (args: FreudButtonComponent) => ({
-  props: { ...args },
-  template: templateHTML.replace(
-    '{{label}}',
-    ''
-  ),
-});
-export const IconOnly = TemplateIcon.bind({});
-IconOnly.args = {
-  icon: 'freud-icon freud-icon-check'
+// With icon 
+export const IconOnly = () => {
+  return {
+    template: `<freud-button [icon]="'freud-icon freud-icon-check'"></freud-button>`,
+  };
+};
+
+export const WithIconRight = () => {
+  return {
+    template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button right'" [iconPos]="'right'"></freud-button>`,
+  };
 }
-export const WithIconRight = TemplateLoading .bind({});
-WithIconRight.args = {
-  icon: 'freud-icon freud-icon-check'
+
+export const WithIconLeft = () => {
+  return {
+    template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button left'"></freud-button>`,
+  };
+}
+
+// With ng-content
+export const WithNGContent = () => {
+  return {
+    template: `<freud-button>Button sem label</freud-button>`,
+  };
 }

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -22,7 +22,7 @@ export const Primary = () => {
 
 export const Secondary = () => {
   return {
-    template: `<freud-button [color]="'secundary'" [label]="'Button secondary'"></freud-button>`,
+    template: `<freud-button [color]="'secondary'" [label]="'Button secondary'"></freud-button>`,
   };
 };
 
@@ -55,7 +55,7 @@ export const BGColorGhost = () => {
 export const Disabled = () => {
   return {
     template: `<freud-button [disabled]="true" [label]="'Button disabled'"></freud-button>`,
-  };BGColorGhost
+  };
 };
 
 // Loading

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -11,7 +11,7 @@ const TemplateTest: Story<FreudButtonComponent> = (args: FreudButtonComponent) =
 export const ButtonTest = TemplateTest.bind({});
 ButtonTest.args = {
   label: 'Teste'
-}
+};
 
 // Theme
 export const Primary = () => {
@@ -63,7 +63,7 @@ export const Loading = () => {
   return {
     template: `<freud-button [loading]="true" [bgColor]="false" [label]="'Button loading'" [iconPos]="'right'"></freud-button>`,
   };
-}
+};
 
 // Sizes
 export const SizeLg = () => {
@@ -95,17 +95,17 @@ export const WithIconRight = () => {
   return {
     template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button right'" [iconPos]="'right'"></freud-button>`,
   };
-}
+};
 
 export const WithIconLeft = () => {
   return {
     template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button left'"></freud-button>`,
   };
-}
+};
 
 // With ng-content
 export const WithNGContent = () => {
   return {
     template: `<freud-button>Button sem label</freud-button>`,
   };
-}
+};

--- a/packages/web/stories/buttons/button/button.stories.mdx
+++ b/packages/web/stories/buttons/button/button.stories.mdx
@@ -1,16 +1,20 @@
-import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
+import { Meta, Canvas, Story, ArgsTable, SourceState } from '@storybook/addon-docs';
 import { moduleMetadata } from '@storybook/angular';
 import { FreudButtonComponent, FreudButtonModule } from '@freud-ds/web-components';
 import { FreudHeaderComponent } from '../../header/header.component';
 import {
+  ButtonTest,
   Primary,
   Secondary,
   Ghost,
-  BGColor,
-  Size,
+  BGColorPrimary, BGColorSecondary, BGColorGhost,
+  SizeLg, SizeMd, SizeSm,
   Disabled,
   Loading,
-  IconOnly, WithIconRight
+  IconOnly, 
+  WithIconRight,
+  WithIconLeft,
+  WithNGContent,
 } from './Button.stories.ts';
 
 <Meta
@@ -36,57 +40,116 @@ title="@freud-ds/web-components/Buttons/Button" component={FreudButtonComponent}
     component: FreudHeaderComponent,
     props: {
       title: "Button",
-      description: "O componente Button é usado para acionar uma ação ou evento."
+      description: "Componente próprio do Freud DS, utilizado para acionar uma ação ou evento."
     },
   }}
 </Story>
 
-## <a id="importing"></a>Import
+## Pré-requisitos
+Estes são alguns pré-requisitos necessários para utilizar os botões do Freud DS:
 
-```ts
-import FreudButtonModule from '@freud-ds/web-components';
+### Libs
+É necessário instalar a lib de componentes do Freud DS para utilizar os botões. Para instalar, rode o comando abaixo 
+no terminal do seu projeto:
+
+#### Web Components
+```bash
+npm i @freud-ds/web-components
 ```
 
-## <a id="exemplos"></a>Exemplos
-<br />
+### Imports
 
-### Theme
-<Canvas>
+#### Módulo
+Importe o `FreudButtonModule` em cada módulo que for utilizar o `FreudButtonComponent`. Utilizando o código:
+```ts
+import { FreudButtonModule } from '@freud-ds/web-components'; 
+
+@NgModule({
+  imports: [
+    FreudButtonModule
+    //e outros imports...
+  ]
+})
+```
+
+## Teste os botões
+Clique em ``Button Test`` (na lista de componentes no canto esquerdo) e depois em ``Canvas`` (no canto superior esquerdo dessa página) 
+para ter acesso a área de testes, onde você pode testar todos os parâmetros do componente `Button`.
+
+<Canvas withSource={SourceState.NONE}>
+  <Story story={ButtonTest}/>
+</Canvas>
+
+## Exemplos de utilização
+
+### Colors
+Por padrão, o botão será exibido na cor `primary` em qualquer situação, mas você pode mudar isso utilizando o parâmetro `color`.
+
+#### Theme
+<Canvas withSource={SourceState.OPEN}>
   <Story story={Primary}/>
   <Story story={Secondary}/>
   <Story story={Ghost}/>
 </Canvas>
 
-### BG Color
-<Canvas style={{ backgroundColor: '#241249' }}>
-  <Story story={BGColor}/>
+#### BG Color
+<Canvas style={{ backgroundColor: '#241249' }} withSource={SourceState.OPEN}>
+  <Story story={BGColorPrimary}/>
+  <Story story={BGColorSecondary}/>
+  <Story story={BGColorGhost}/>
 </Canvas>
 
-### Size
-<Canvas>
-  <Story story={Size}/>
+### Sizes
+Por padrão, o botão será exibido no tamanho `md`, mas você pode mudar isso utilizando o parâmetro `size`.
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={SizeLg}/>
+  <Story story={SizeMd}/>
+  <Story story={SizeSm}/>
 </Canvas>
 
 ### Disabled
-<Canvas>
+<Canvas withSource={SourceState.OPEN}>
   <Story story={Disabled}/>
 </Canvas>
 
 ### Loading
-<Canvas>
+<Canvas withSource={SourceState.OPEN}>
   <Story story={Loading}/>
 </Canvas>
 
-### Icon-Only
-<Canvas>
+### With icon
+
+#### Icon Only
+<Canvas withSource={SourceState.OPEN}>
   <Story story={IconOnly}/>
 </Canvas>
 
-### With Icon Right
-<Canvas>
+#### Icon position
+Por padrão, o ícone será exibido a esquerda do `label`, mas você pode mudar isso utilizando o parâmetro `iconPos`.
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={WithIconLeft}/>
   <Story story={WithIconRight}/>
 </Canvas>
 
-## <a id="api"></a>API
+## Outra forma de utilização
+Além de utilizar `label`, você também pode utilizar outro meio para inserir o texto do botão, o `ng-content`. 
+Porém **recomenda-se** utilizar da forma apresentada acima, com o `label`, que é a forma padrão do Freud DS.
+Caso você opte por utilizar o `ng-content`, leve em consideração que **não** será possível mudar a posição do ícone no componente, 
+isso só ocorre com a utilização do `label`.
+
+**ATENÇÃO**: se você já utilizava o componente `Button` antes dessa atualização, é necessário e recomendado alterar a utilização do texto do botão de `ng-content` para `label`, 
+garantindo que você possa modificar a posição do ícone do botão, além de estar utilizando o novo padrão estabelecido pelo Freud DS.
+
+Para utilizar é simples, basta não passar o `label` e inserir o texto dentro da *tag* do componente, como no exemplo abaixo:
+
+**--> os outros parâmetros continuam funcionando da mesma forma!**
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={WithNGContent}/>
+</Canvas>
+
+## API
 
 <ArgsTable of={FreudButtonComponent} />


### PR DESCRIPTION
Alguns ajustes para que o ícone do botão seja exibido a esquerda como padrão e possa ser exibido a direita por meio do `[iconPos]`.
Ajustes na documentação para a nova utilização do componente button, que agora tem como padrão a utilização do `[label]`, agora tenho retrocompatibilidade com `<ng-content>`.
Ajustes no `.scss` para padronizar paddings entre ícone e conteúdo do botão.