### PR TITLE
feat: adding new sizes to Icon component

### DIFF
--- a/packages/web/projects/web-components/package-lock.json
+++ b/packages/web/projects/web-components/package-lock.json
@@ -1,57 +1,8 @@
 {
   "name": "@freud-ds/web-components",
   "version": "2.11.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "@freud-ds/web-components",
-      "version": "2.11.0",
-      "dependencies": {
-        "primeicons": "^6.0.1",
-        "primeng": "^12.2.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "~12.2.0",
-        "@angular/cdk": "~12.2.0",
-        "@angular/common": "^12.2.0",
-        "@angular/core": "^12.2.0",
-        "@freud-ds/icons": "^2.2.0",
-        "@freud-ds/tokens": "^2.0.7",
-        "@fullcalendar/angular": "^6.0.1",
-        "@fullcalendar/core": "^6.0.1",
-        "@fullcalendar/daygrid": "^6.0.1",
-        "@fullcalendar/interaction": "^6.0.1",
-        "@fullcalendar/timegrid": "^6.0.1"
-      }
-    },
-    "node_modules/primeicons": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-6.0.1.tgz",
-      "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
-    },
-    "node_modules/primeng": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-12.2.2.tgz",
-      "integrity": "sha512-PB2kZzwhAb3M5nQXe1hUfsBGXAbhGcf/NVwg8mp4P5JETJ4nAGgixNPPGjBdmFW6l8QzmlsAVb3nMF+rPaZH4g==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "@angular/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "@angular/forms": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "rxjs": "^6.0.0",
-        "zone.js": "^0.10.2 || ^0.11.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-    }
-  },
   "dependencies": {
     "primeicons": {
       "version": "6.0.1",

--- a/packages/web/projects/web-components/src/components/icons/icon/icon.component.scss
+++ b/packages/web/projects/web-components/src/components/icons/icon/icon.component.scss
@@ -1,3 +1,10 @@
+.freud-icon-sm {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  line-height: 1;
+}
+
 .freud-icon-md {
   font-size: 24px;
   width: 24px;
@@ -5,10 +12,24 @@
   line-height: 1;
 }
 
-.freud-icon-sm {
-  font-size: 16px;
-  width: 16px;
-  height: 16px;
+.freud-icon-lg {
+  font-size: 32px;
+  width: 32px;
+  height: 32px;
+  line-height: 1;
+}
+
+.freud-icon-xl {
+  font-size: 40px;
+  width: 40px;
+  height: 40px;
+  line-height: 1;
+}
+
+.freud-icon-xxl {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
   line-height: 1;
 }
 

--- a/packages/web/projects/web-components/src/components/icons/icon/icon.component.ts
+++ b/packages/web/projects/web-components/src/components/icons/icon/icon.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ViewEncapsulation } from '@angular/core';
 
-export const FreudIconSizes = ['sm', 'md'] as const;
+export const FreudIconSizes = ['sm', 'md', 'lg', 'xl', 'xxl'] as const;
 export type FreudIconSize = typeof FreudIconSizes[number];
 
 @Component({
@@ -24,7 +24,13 @@ export class FreudIconComponent {
     }
     if (this.size === 'sm') {
       classes.push('freud-icon-sm');
-    } else{
+    } else if (this.size === 'lg') {
+      classes.push('freud-icon-lg');
+    } else if (this.size === 'xl') {
+      classes.push('freud-icon-xl');
+    } else if (this.size === 'xxl') {
+      classes.push('freud-icon-xxl');
+    } else {
       classes.push('freud-icon-md');
     }
     

--- a/packages/web/stories/icons/icon-component/Icon.stories.ts
+++ b/packages/web/stories/icons/icon-component/Icon.stories.ts
@@ -27,15 +27,33 @@ const Template: Story<FreudIconComponent> = (args: FreudIconComponent) => ({
   template: `<freud-icon [icon]="icon" [size]="size"></freud-icon>`,
 });
 
-export const Icon = () => {
+export const IconSM = () => {
+  return {
+    template: `<freud-icon icon="award" size="sm"></freud-icon>`,
+  };
+};
+
+export const IconMD = () => {
   return {
     template: `<freud-icon icon="award"></freud-icon>`,
   };
 };
 
-export const IconSmall = () => {
+export const IconLG = () => {
   return {
-    template: `<freud-icon icon="award" size="sm"></freud-icon>`,
+    template: `<freud-icon icon="award" size="lg"></freud-icon>`,
+  };
+};
+
+export const IconXL = () => {
+  return {
+    template: `<freud-icon icon="award" size="xl"></freud-icon>`,
+  };
+};
+
+export const IconXXL = () => {
+  return {
+    template: `<freud-icon icon="award" size="xxl"></freud-icon>`,
   };
 };
 

--- a/packages/web/stories/icons/icon-component/icon.stories.mdx
+++ b/packages/web/stories/icons/icon-component/icon.stories.mdx
@@ -4,7 +4,7 @@ import { moduleMetadata } from "@storybook/angular";
 import { FreudIconComponent, FreudIconModule, FreudIconSizes, FreudTypographyModule, FreudInputTextModule} from "@freud-ds/web-components";
 import { FreudHeaderComponent } from "../../header/header.component";
 
-import { Icon, IconSmall, IconTest, AllIcons } from "./Icon.stories";
+import { IconSM, IconMD, IconLG, IconXL, IconXXL, IconTest, AllIcons } from "./Icon.stories";
 
 <Meta
   decorators={[
@@ -122,11 +122,23 @@ para ter acesso a área de testes, onde você pode colocar os ícones da lista p
 ### Exemplo
 
 <Canvas withSource={SourceState.OPEN}>
-  <Story story={Icon}/>
+  <Story story={IconSM}/>
 </Canvas>
 
 <Canvas withSource={SourceState.OPEN}>
-  <Story story={IconSmall}/>
+  <Story story={IconMD}/>
+</Canvas>
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={IconLG}/>
+</Canvas>
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={IconXL}/>
+</Canvas>
+
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={IconXXL}/>
 </Canvas>
 
 ## Lista de ícones disponíveis


### PR DESCRIPTION
Nessa tarefa adicionei 3 novos tamanhos para o `Icon Component`, `LG (32px)`, `XL (40px)` e `XXL (48px)`. Também atualizei a documentação do `StoryBook` para mostrar esses novos tamanhos.