### PR TITLE
feat: adding maxWidth parameter and updating storybook

### DIFF
--- a/packages/web/projects/web-components/src/components/feedback/tooltip/tooltip.component.ts
+++ b/packages/web/projects/web-components/src/components/feedback/tooltip/tooltip.component.ts
@@ -7,18 +7,39 @@ type position = 'top' | 'bottom' | 'left' | 'right';
   selector: '[freud-tooltip]',
   exportAs: 'freudTooltip',
   template: `
-    <div [pTooltip]="tooltipLabel" [tooltipPosition]="tooltipPosition" [class.bgColor]="bgColor"
-        [tooltipStyleClass]="bgColor ? 'freud-tooltip freud-bg-color' : 'freud-tooltip'" class="freud-tooltip-container">
+    <div
+      (mouseenter)="handleMouseEnter()"
+      [pTooltip]="tooltipLabel"
+      [tooltipPosition]="tooltipPosition"
+      [class.bgColor]="bgColor"
+      [tooltipStyleClass]="bgColor ? 'freud-tooltip freud-bg-color' : 'freud-tooltip'"
+      class="freud-tooltip-container"
+    >
       <ng-content></ng-content>
     </div>
   `,
   styleUrls: ['./tooltip.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
 })
 export class FreudTooltipComponent {
-
   @Input() tooltipLabel: string = '';
   @Input() tooltipPosition: position = 'top';
   @Input() bgColor: boolean = false;
+  @Input() maxWidth: number = 690;
 
+  handleMouseEnter() {
+    setTimeout(() => {
+      const tooltip = document.querySelector('.freud-tooltip');
+      if (!tooltip) return;
+      const tooltipMaxWidth = this.maxWidthLimiter(this.maxWidth, 690);
+      (tooltip as HTMLElement).style.maxWidth = `${tooltipMaxWidth}px`;
+    });
+  }
+
+  maxWidthLimiter(width: number, maxWidthLimit: number): number {
+    if (width > maxWidthLimit) {
+      console.warn('Tooltip: maxWidth exceeded');
+    }
+    return Math.min(width, maxWidthLimit);
+  }
 }

--- a/packages/web/stories/feedback/tooltip/Tooltip.stories.ts
+++ b/packages/web/stories/feedback/tooltip/Tooltip.stories.ts
@@ -9,7 +9,8 @@ const Template: Story<FreudTooltipComponent> = (
     <span freud-tooltip
       [tooltipLabel]="tooltipLabel"
       [tooltipPosition]="tooltipPosition"
-      [bgColor]="bgColor">
+      [bgColor]="bgColor"
+      [maxWidth]="maxWidth">
       <span style="color:{{bgColor ? 'white' : 'black'}}; font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
     </span>
   `,
@@ -17,6 +18,37 @@ const Template: Story<FreudTooltipComponent> = (
 
 //Teste
 export const TooltipTest = Template.bind({});
+
+// MaxWidth
+export const MaxWidthSmall = () => {
+  return {
+    template: `
+      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" maxWidth="100">
+        <span style="font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
+      </span>
+    `,
+  };
+};
+
+export const MaxWidthDefault = () => {
+  return {
+    template: `
+      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom">
+        <span style="font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
+      </span>
+    `,
+  };
+};
+
+export const MaxWidthLarge = () => {
+  return {
+    template: `
+      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" maxWidth="800">
+        <span style="font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
+      </span>
+    `,
+  };
+};
 
 // Position
 export const Top = () => {

--- a/packages/web/stories/feedback/tooltip/tooltip.stories.mdx
+++ b/packages/web/stories/feedback/tooltip/tooltip.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Canvas, Story, ArgsTable, SourceState } from "@storybook/addon-do
 import { moduleMetadata } from "@storybook/angular";
 import { FreudTooltipComponent, FreudTooltipModule } from "@freud-ds/web-components";
 import { FreudHeaderComponent } from "../../header/header.component";
-import { Top, Bottom, Left, Right, BGColor, TooltipTest, Disabled } from "./Tooltip.stories.ts";
+import { Top, Bottom, Left, Right, BGColor, TooltipTest, Disabled, MaxWidthSmall, MaxWidthDefault, MaxWidthLarge } from "./Tooltip.stories.ts";
 
 <Meta
   decorators={[
@@ -67,6 +67,31 @@ para ter acesso a área de testes, onde você pode testar todos os exemplos list
 ## Exemplos de uso
 Cada um dos exemplos são apresentados separadamente, mas nada impede que mais de um parâmetro seja utilizado ao mesmo tempo, desde que a lógica de uso faça sentido.
 
+### Largura máxima
+Por padrão, o ``Tooltip`` tem uma largura máxima de ``690px``. Para alterar esse valor, basta passar o parâmetro ``maxWidth`` com apenas o número desejado, 
+sem usar ``px`` ao final. 
+
+**OBS.:** Vale lembrar que o valor máximo é de ``690px``, então qualquer valor acima disso será ignorado e o valor padrão será utilizado. 
+Apenas valores menores serão considerados e modificarão a largura máxima do Tooltip.
+
+**Recomendação:** O objetivo principal de um ``Tooltip`` é dar dicas ou informações pequenas, ou seja, um texto muito grande não seria o indicado para esses momentos. 
+Ao utilizar o componente, opte por frases curtas e objetivas, mantendo esse comportamento, não há necessidade de alcançar os ``690px`` do ``maxWidth``.
+
+#### Small
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={MaxWidthSmall} /> 
+</Canvas>
+
+#### Default
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={MaxWidthDefault} />
+</Canvas>
+
+#### Large
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={MaxWidthLarge} />
+</Canvas>
+
 ### Direções
 Por padrão, o Tooltip aparece na direção ``top``. Para alterar a direção, basta passar o parâmetro ``direction`` com o valor desejado:
 
@@ -99,7 +124,7 @@ Por padrão, o Tooltip aparece na direção ``top``. Para alterar a direção, b
 ### Tooltip disabled
 Existe uma possibilidade de desabilitar o Tooltip, para isso basta passar o parâmetro ``tooltipLabel`` com o valor vazio ou com a condição que desejar.
 
-#### Vazio
+#### Null
 <Canvas withSource={SourceState.OPEN}>
   <Story story={Disabled} />
 </Canvas>


### PR DESCRIPTION
Nessa tarefa adicionei um parâmetro maxWidth responsável por limitar a largura máxima do Tooltip a 690px e ainda permitir que possa ser passado um valor qualquer como maxWidth. Também atualizei a documentação para descrever esse novo comportamento.

OBS.: coloquei algumas informações no tópico tamanhos, tentando passar o máximo de dicas possíveis, mas não sei se essa quantidade de texto seria o ideal para a documentação.