### PR TITLE
feat: fixing maxWidth use in the documentation

### DIFF
--- a/packages/web/stories/feedback/tooltip/Tooltip.stories.ts
+++ b/packages/web/stories/feedback/tooltip/Tooltip.stories.ts
@@ -23,7 +23,7 @@ export const TooltipTest = Template.bind({});
 export const MaxWidthSmall = () => {
   return {
     template: `
-      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" maxWidth="100">
+      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" [maxWidth]="100">
         <span style="font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
       </span>
     `,
@@ -43,7 +43,7 @@ export const MaxWidthDefault = () => {
 export const MaxWidthLarge = () => {
   return {
     template: `
-      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" maxWidth="800">
+      <span freud-tooltip tooltipLabel="Tooltip label teste de maxWidth | Tooltip label teste de maxWidth | Tooltip label teste de maxWidth" tooltipPosition="bottom" [maxWidth]="800">
         <span style="font-family: 'Source Sans Pro'">Passe o mouse aqui!</span>
       </span>
     `,


### PR DESCRIPTION
Nessa tarefa eu apenas corrigir um erro de escrita na documentação do componente `Tooltip` que poderia atrapalhar sua utilização.

- Antes: `maxWidth="300"`;
- Agora: `[maxWidth]="300"`.

Caso não seja utilizado os `[ ]`, acontecerá um erro, porque o número passado será interpretado como `string` e não como `number`.