### PR TITLE
feat: adding fullWidth to component and updating documentation

### DIFF
--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.scss
@@ -93,6 +93,13 @@
   }
 }
 
+.freud-btn-full-width {
+  .p-button {
+    width: 100%;
+    display: block;
+  }
+}
+
 .freud-btn-size-small {
   .p-button {
     font-size: $font-size-xxs;
@@ -151,4 +158,3 @@
     margin-left: 16px;
   }
 }
-

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -40,7 +40,7 @@ type iconPos = 'left' | 'right';
     '[class.freud-btn-size-medium]': `size === 'md'`,
     '[class.freud-btn-size-large]': `size === 'lg'`,
 
-    '[class.freud-btn-full-width]': `fullWidth ? 'freud-btn-full-width' : ''`,
+    '[class.freud-btn-full-width]': `fullWidth`,
   },
 })
 export class FreudButtonComponent {

--- a/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
+++ b/packages/web/projects/web-components/src/components/buttons/button/button.component.ts
@@ -22,6 +22,7 @@ type iconPos = 'left' | 'right';
       [type]="type"
       [label]="label"
       [iconPos]="iconPos"
+      [fullWidth]="fullWidth"
     >
       <div class="button-content" *ngIf="!label"><ng-content></ng-content></div>
     </p-button>
@@ -38,6 +39,8 @@ type iconPos = 'left' | 'right';
     '[class.freud-btn-size-small]': `size === 'sm'`,
     '[class.freud-btn-size-medium]': `size === 'md'`,
     '[class.freud-btn-size-large]': `size === 'lg'`,
+
+    '[class.freud-btn-full-width]': `fullWidth ? 'freud-btn-full-width' : ''`,
   },
 })
 export class FreudButtonComponent {
@@ -57,4 +60,5 @@ export class FreudButtonComponent {
   @Input() icon: string = '';
   @Input() label: string = '';
   @Input() iconPos: iconPos = 'left';
+  @Input() fullWidth: boolean = false;
 }

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -87,7 +87,7 @@ export const SizeSm = () => {
 // Full Width
 export const fullWidth = () => {
   return {
-    template: `<freud-button [bgColor]="bgColor" [fullWidth]="true" label="Button fullWidth"></freud-button>`,
+    template: `<freud-button [bgColor]="bgColor" fullWidth="true" label="Button fullWidth"></freud-button>`,
   };
 };
 

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -16,90 +16,97 @@ ButtonTest.args = {
 // Theme
 export const Primary = () => {
   return {
-    template: `<freud-button [label]="'Button primary'"></freud-button>`,
+    template: `<freud-button label="Button primary"></freud-button>`,
   };
 };
 
 export const Secondary = () => {
   return {
-    template: `<freud-button [color]="'secondary'" [label]="'Button secondary'"></freud-button>`,
+    template: `<freud-button color="secondary" label="Button secondary"></freud-button>`,
   };
 };
 
 export const Ghost = () => {
   return {
-    template: `<freud-button [color]="'ghost'" [label]="'Button ghost'"></freud-button>`,
+    template: `<freud-button color="ghost" label="Button ghost"></freud-button>`,
   };
 };
 
 // Background
 export const BGColorPrimary = () => {
   return {
-    template: `<freud-button [bgColor]="true" [label]="'ButtonBG primary'"></freud-button>`,
+    template: `<freud-button [bgColor]="true" label="ButtonBG primary"></freud-button>`,
   };
 };
 
 export const BGColorSecondary = () => {
   return {
-    template: `<freud-button [bgColor]="true" [color]="'secondary'" [label]="'ButtonBG secondary'"></freud-button>`,
+    template: `<freud-button [bgColor]="true" color="secondary" label="ButtonBG secondary"></freud-button>`,
   };
 };
 
 export const BGColorGhost = () => {
   return {
-    template: `<freud-button [bgColor]="true" [color]="'ghost'" [label]="'ButtonBG ghost'"></freud-button>`,
+    template: `<freud-button [bgColor]="true" color="ghost" label="ButtonBG ghost"></freud-button>`,
   };
 };
 
 // Disabled
 export const Disabled = () => {
   return {
-    template: `<freud-button [disabled]="true" [label]="'Button disabled'"></freud-button>`,
+    template: `<freud-button [disabled]="true" label="Button disabled"></freud-button>`,
   };
 };
 
 // Loading
 export const Loading = () => {
   return {
-    template: `<freud-button [loading]="true" [bgColor]="false" [label]="'Button loading'" [iconPos]="'right'"></freud-button>`,
+    template: `<freud-button [loading]="true" [bgColor]="false" label="Button loading" iconPos="right"></freud-button>`,
   };
 };
 
 // Sizes
 export const SizeLg = () => {
   return {
-    template: `<freud-button [bgColor]="bgColor" [size]="'lg'" [label]="'Button large'"></freud-button>`,
+    template: `<freud-button [bgColor]="bgColor" size="lg" label="Button large"></freud-button>`,
   };
 };
 
 export const SizeMd = () => {
   return {
-    template: `<freud-button [bgColor]="bgColor" [size]="'md'" [label]="'Button medium'"></freud-button>`,
+    template: `<freud-button [bgColor]="bgColor" size="md" label="Button medium"></freud-button>`,
   };
 };
 
 export const SizeSm = () => {
   return {
-    template: `<freud-button [bgColor]="bgColor" [size]="'sm'" [label]="'Button small'"></freud-button>`,
+    template: `<freud-button [bgColor]="bgColor" size="sm" label="Button small"></freud-button>`,
+  };
+};
+
+// Full Width
+export const fullWidth = () => {
+  return {
+    template: `<freud-button [bgColor]="bgColor" [fullWidth]="true" label="Button fullWidth"></freud-button>`,
   };
 };
 
 // With icon 
 export const IconOnly = () => {
   return {
-    template: `<freud-button [icon]="'freud-icon freud-icon-check'"></freud-button>`,
+    template: `<freud-button icon="freud-icon freud-icon-check"></freud-button>`,
   };
 };
 
 export const WithIconRight = () => {
   return {
-    template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button right'" [iconPos]="'right'"></freud-button>`,
+    template: `<freud-button icon="freud-icon freud-icon-check" label="Button right" iconPos="right"></freud-button>`,
   };
 };
 
 export const WithIconLeft = () => {
   return {
-    template: `<freud-button [icon]="'freud-icon freud-icon-check'" [label]="'Button left'"></freud-button>`,
+    template: `<freud-button icon="freud-icon freud-icon-check" label="Button left"></freud-button>`,
   };
 };
 

--- a/packages/web/stories/buttons/button/Button.stories.ts
+++ b/packages/web/stories/buttons/button/Button.stories.ts
@@ -87,7 +87,7 @@ export const SizeSm = () => {
 // Full Width
 export const fullWidth = () => {
   return {
-    template: `<freud-button [bgColor]="bgColor" fullWidth="true" label="Button fullWidth"></freud-button>`,
+    template: `<freud-button [bgColor]="bgColor" [fullWidth]="true" label="Button fullWidth"></freud-button>`,
   };
 };
 

--- a/packages/web/stories/buttons/button/button.stories.mdx
+++ b/packages/web/stories/buttons/button/button.stories.mdx
@@ -9,6 +9,7 @@ import {
   Ghost,
   BGColorPrimary, BGColorSecondary, BGColorGhost,
   SizeLg, SizeMd, SizeSm,
+  fullWidth,
   Disabled,
   Loading,
   IconOnly, 
@@ -106,6 +107,14 @@ Por padrão, o botão será exibido no tamanho `md`, mas você pode mudar isso u
   <Story story={SizeLg}/>
   <Story story={SizeMd}/>
   <Story story={SizeSm}/>
+</Canvas>
+
+### Full Width
+Por padrão, o botão não ocupará a largura total do seu container, mas você pode mudar isso utilizando o parâmetro `fullWidth`.
+ 
+**OBS.: O parâmetro só aceita valores booleanos, ou seja, ``true`` ou ``false``.**
+<Canvas withSource={SourceState.OPEN}>
+  <Story story={fullWidth}/>
 </Canvas>
 
 ### Disabled


### PR DESCRIPTION
Nessa tarefa eu criei um parâmetro `fullWidth` para o componente, onde, caso ele seja true, usará a classe de estilo responsável pelo `width: 100%` e `display: block`. Além disso, atualizei a documentação descrevendo o comportamento novo e aproveitei para atualizar os exemplos da documentação para deixar o exemplo do código mais claro.