### PR TITLE
feat: added tags for options in freud select

### DIFF
--- a/packages/web/projects/web-components/src/components/forms/select/select.component.html
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.html
@@ -1,35 +1,50 @@
 <div class="freud-field" [class.disabled]="disabled">
-    <label for="{{id}}" class="freud-typography bodySemibold1-2 freud-label" *ngIf="label">{{label}}</label>
-    <p-dropdown
-      [id]="id"
-      [class.ng-invalid]="invalid"
-      [class.ng-dirty]="invalid"
-      [(ngModel)]="value"
-      [optionLabel]="optionLabel"
-      [optionValue]="optionValue"
-      [optionDisabled]="optionDisabled"
-      [optionGroupLabel]="optionGroupLabel"
-      [optionGroupChildren]="optionGroupChildren"
-      [placeholder]="placeholder || ''"
-      [virtualScroll]="virtualScroll"
-      [dropdownIcon]="dropdownIcon"
-      [emptyMessage]="emptyMessage"
-      [itemSize]="itemSize"
-      [disabled]="disabled"
-      [required]="required"
-      [filter]="filter"
-      [options]="options"
-      (onFocus)="onFocus.emit($event)"
-      (onBlur)="onBlur.emit($event)"
-      (onChange)="onChange.emit($event)"
-      (onFilter)="onFilter.emit($event)"
-      (onShow)="onShow.emit($event)"
-      (onHide)="onHide.emit($event)"
-      (onClear)="onClear.emit($event)"
-
-    ></p-dropdown>
-    <small
-      [class.disabled]="disabled"
-      *ngIf="helpText"
-      class="help-text freud-typography bodyRegularAuto">{{helpText}}</small>
-  </div>
+  <label
+    for="{{ id }}"
+    class="freud-typography bodySemibold1-2 freud-label"
+    *ngIf="label"
+    >{{ label }}</label
+  >
+  <p-dropdown
+    [id]="id"
+    [class.ng-invalid]="invalid"
+    [class.ng-dirty]="invalid"
+    [(ngModel)]="value"
+    [optionLabel]="optionLabel"
+    [optionValue]="optionValue"
+    [optionDisabled]="optionDisabled"
+    [optionGroupLabel]="optionGroupLabel"
+    [optionGroupChildren]="optionGroupChildren"
+    [placeholder]="placeholder || ''"
+    [virtualScroll]="virtualScroll"
+    [dropdownIcon]="dropdownIcon"
+    [emptyMessage]="emptyMessage"
+    [itemSize]="itemSize"
+    [disabled]="disabled"
+    [required]="required"
+    [filter]="filter"
+    [options]="options"
+    (onFocus)="onFocus.emit($event)"
+    (onBlur)="onBlur.emit($event)"
+    (onChange)="onChange.emit($event)"
+    (onFilter)="onFilter.emit($event)"
+    (onShow)="onShow.emit($event)"
+    (onHide)="onHide.emit($event)"
+    (onClear)="onClear.emit($event)"
+  >
+    <ng-template let-item pTemplate="item" *ngIf="useItemTemplate">
+      <div class="flex align-items-center gap-2">
+        <div>{{ optionLabel ? item[optionLabel] : item.label }}</div>
+        <div class="tags" *ngIf="item.tags?.length > 0">
+          <div  class="select__tag" *ngFor="let tag of item.tags">{{ tag.label }}</div>
+        </div>
+      </div>
+    </ng-template>
+  </p-dropdown>
+  <small
+    [class.disabled]="disabled"
+    *ngIf="helpText"
+    class="help-text freud-typography bodyRegularAuto"
+    >{{ helpText }}</small
+  >
+</div>

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.html
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.html
@@ -36,7 +36,9 @@
       <div class="flex align-items-center gap-2">
         <div>{{ optionLabel ? item[optionLabel] : item.label }}</div>
         <div class="tags" *ngIf="item.tags?.length > 0">
-          <div  class="select__tag" *ngFor="let tag of item.tags">{{ tag.label }}</div>
+          <div class="select__tag" *ngFor="let tag of item.tags">
+            {{ tag.label }}
+          </div>
         </div>
       </div>
     </ng-template>

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.scss
@@ -83,11 +83,11 @@
     gap: 5px;
     margin-top: 10px;
     .select__tag{
-      background-color: #EEE6FC;
-      border-radius: 8px;
-      padding: 4px 8px 4px 8px;
-      font-size: 14px;
-      color:#6732D1;
+      background-color: $brand-color-01;
+      border-radius: $border-radius-md;
+      padding: $spacing-size-quark $spacing-size-nano $spacing-size-quark $spacing-size-nano;
+      font-size: $font-size-xxs;
+      color: $brand-color-pure;
       width: min-content;
     }
   }

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.scss
@@ -66,11 +66,30 @@
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     background-color: $brand-color-01;
     color: $brand-color-pure;
+    .select__tag{
+      background-color: white!important;
+    }
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight {
     background-color: $brand-color-01;
     color: $brand-color-pure;
+    .select__ta{
+      background-color: white!important;
+    }
+  }
+  .tags{
+    display: inline-flex;
+    gap: 5px;
+    margin-top: 10px;
+    .select__tag{
+      background-color: #EEE6FC;
+      border-radius: 8px;
+      padding: 4px 8px 4px 8px;
+      font-size: 14px;
+      color:#6732D1;
+      width: min-content;
+    }
   }
 }
 

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.scss
@@ -1,14 +1,16 @@
-@import '../../../../../../../tokens/dist/style/scss/variables';
-@import '../../../../scss/typography';
+@import "../../../../../../../tokens/dist/style/scss/variables";
+@import "../../../../scss/typography";
 
 .freud-select:not(.freud-bgcolor) {
-  .freud-label, .help-text {
+  .freud-label,
+  .help-text {
     color: $neutral-color-dark-04;
   }
 }
 
 .freud-select.freud-bgcolor {
-  .freud-label, .help-text {
+  .freud-label,
+  .help-text {
     color: $neutral-color-white;
   }
 }
@@ -66,23 +68,24 @@
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     background-color: $brand-color-01;
     color: $brand-color-pure;
-    .select__tag{
-      background-color: white!important;
+    .select__tag {
+      background-color: white !important;
     }
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight {
     background-color: $brand-color-01;
     color: $brand-color-pure;
-    .select__ta{
-      background-color: white!important;
+    .select__tag {
+      background-color: white !important;
     }
   }
-  .tags{
+  .tags {
     display: inline-flex;
+    flex-wrap: wrap;
     gap: 5px;
     margin-top: 10px;
-    .select__tag{
+    .select__tag {
       background-color: $brand-color-01;
       border-radius: $border-radius-md;
       padding: $spacing-size-quark $spacing-size-nano $spacing-size-quark $spacing-size-nano;
@@ -92,4 +95,3 @@
     }
   }
 }
-

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.ts
@@ -37,7 +37,7 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Input() itemSize!: number;
   @Input() emptyMessage: string = 'Sem resultados';
   @Input() dropdownIcon: string = 'freud-icon freud-icon-chevron-down';
-  @Input() optionLabel!: string;
+  @Input() optionLabel: string = 'label'
   @Input() optionValue!: string;
   @Input() optionDisabled: string = 'disabled';
   @Input() optionGroupLabel: string = 'label';
@@ -48,7 +48,7 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Input() disabled = false;
   @Input() required: boolean = false;
   @Input() id!: string;
-
+  @Input() useItemTemplate = false
   @Output() onFocus: EventEmitter<any> = new EventEmitter();
 
   @Output() onBlur: EventEmitter<any> = new EventEmitter();

--- a/packages/web/projects/web-components/src/components/forms/select/select.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.ts
@@ -4,9 +4,9 @@ import {
   forwardRef,
   Input,
   Output,
-  ViewEncapsulation
+  ViewEncapsulation,
 } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
   selector: 'freud-select',
@@ -21,9 +21,9 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
     {
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => FreudSelectComponent),
-      multi: true
-    }
-  ]
+      multi: true,
+    },
+  ],
 })
 export class FreudSelectComponent implements ControlValueAccessor {
   @Input() label: string = '';
@@ -37,7 +37,7 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Input() itemSize!: number;
   @Input() emptyMessage: string = 'Sem resultados';
   @Input() dropdownIcon: string = 'freud-icon freud-icon-chevron-down';
-  @Input() optionLabel: string = 'label'
+  @Input() optionLabel: string = 'label';
   @Input() optionValue!: string;
   @Input() optionDisabled: string = 'disabled';
   @Input() optionGroupLabel: string = 'label';
@@ -48,7 +48,7 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Input() disabled = false;
   @Input() required: boolean = false;
   @Input() id!: string;
-  @Input() useItemTemplate = false
+  @Input() useItemTemplate = false;
   @Output() onFocus: EventEmitter<any> = new EventEmitter();
 
   @Output() onBlur: EventEmitter<any> = new EventEmitter();
@@ -60,7 +60,6 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Output() onHide: EventEmitter<any> = new EventEmitter();
   @Output() onClear: EventEmitter<any> = new EventEmitter();
   @Output() valueChange: EventEmitter<any> = new EventEmitter();
-
 
   private _value!: string;
 
@@ -76,12 +75,11 @@ export class FreudSelectComponent implements ControlValueAccessor {
     this.onModelTouched = fn;
   }
 
-  setDisabledState?(isDisabled: boolean): void {
-  }
+  setDisabledState?(isDisabled: boolean): void {}
 
-  onModelChange: any = () => { };
+  onModelChange: any = () => {};
 
-  onModelTouched: any = () => { };
+  onModelTouched: any = () => {};
 
   onSomeEventOccured(newValue: string) {
     this.value = newValue;
@@ -97,12 +95,10 @@ export class FreudSelectComponent implements ControlValueAccessor {
       this.onModelChange(this._value);
     }
 
-
     if (typeof this.onModelTouched === 'function') {
       this.onModelTouched();
     }
 
     this.valueChange.emit(v);
   }
-
 }

--- a/packages/web/stories/forms/select/Select.stories.ts
+++ b/packages/web/stories/forms/select/Select.stories.ts
@@ -1,7 +1,7 @@
 import { Story } from '@storybook/angular';
 import { FreudSelectComponent } from '@freud-ds/web-components';
-import { BrowserModule } from "@angular/platform-browser";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { moduleMetadata } from '@storybook/angular';
 
 const items = [
@@ -40,7 +40,7 @@ Default.args = {
   placeholder: 'Placeholder',
   options: items,
   optionLabel: 'name',
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export const BGColor = Template.bind({});
@@ -51,7 +51,7 @@ BGColor.args = {
   helpText: 'Helper Text',
   options: items,
   optionLabel: 'name',
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export const Filter = Template.bind({});
@@ -62,7 +62,7 @@ Filter.args = {
   placeholder: 'Placeholder',
   options: items,
   optionLabel: 'name',
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export const Disabled = Template.bind({});
@@ -71,7 +71,7 @@ Disabled.args = {
   disabled: true,
   options: items,
   optionLabel: 'name',
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export const Invalid = Template.bind({});
@@ -81,7 +81,7 @@ Invalid.args = {
   invalid: true,
   options: items,
   optionLabel: 'name',
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export const Tags = Template.bind({});
@@ -91,21 +91,27 @@ Tags.args = {
   placeholder: 'Placeholder',
   invalid: true,
   options: [
-    { label: 'New York', code: 'NY', tags: [ { label: 'Conteúdos'}, {label: 'Autoavaliações'},{label: 'Sessões de psicoterapia (16)'}, {label: 'Sessões de psiquiatria'}] },
+    {
+      label: 'New York',
+      code: 'NY',
+      tags: [
+        { label: 'Conteúdos' },
+        { label: 'Autoavaliações' },
+        { label: 'Sessões de psicoterapia (16)' },
+        { label: 'Sessões de psiquiatria' },
+      ],
+    },
     { label: 'Rome', code: 'RM', disabled: true },
     { label: 'London', code: 'LDN' },
     { label: 'Istanbul', code: 'IST' },
   ],
-  optionValue: 'code'
+  optionValue: 'code',
 };
 
 export default {
   decorators: [
     moduleMetadata({
-      imports: [
-        BrowserModule,
-        BrowserAnimationsModule
-      ]
-    })
-  ]
-}
+      imports: [BrowserModule, BrowserAnimationsModule],
+    }),
+  ],
+};

--- a/packages/web/stories/forms/select/Select.stories.ts
+++ b/packages/web/stories/forms/select/Select.stories.ts
@@ -16,6 +16,7 @@ const templateHTML = `
         <freud-select
           [disabled]="disabled"
           [label]="label"
+          [useItemTemplate]="useItemTemplate"
           [options]="options"
           [optionLabel]="optionLabel"
           [filter]="filter"
@@ -80,6 +81,21 @@ Invalid.args = {
   invalid: true,
   options: items,
   optionLabel: 'name',
+  optionValue: 'code'
+};
+
+export const Tags = Template.bind({});
+Tags.args = {
+  label: 'Label',
+  useItemTemplate: true,
+  placeholder: 'Placeholder',
+  invalid: true,
+  options: [
+    { label: 'New York', code: 'NY', tags: [ { label: 'Conteúdos'}, {label: 'Autoavaliações'},{label: 'Sessões de psicoterapia (16)'}, {label: 'Sessões de psiquiatria'}] },
+    { label: 'Rome', code: 'RM', disabled: true },
+    { label: 'London', code: 'LDN' },
+    { label: 'Istanbul', code: 'IST' },
+  ],
   optionValue: 'code'
 };
 

--- a/packages/web/stories/forms/select/select.stories.mdx
+++ b/packages/web/stories/forms/select/select.stories.mdx
@@ -7,7 +7,8 @@ import {
   BGColor,
   Disabled,
   Invalid,
-  Filter
+  Filter,
+  Tags
 } from './Select.stories.ts';
 
 <Meta
@@ -70,6 +71,20 @@ import { FreudSelectModule } from '@freud-ds/web-components';
 ### BG Color
 <Canvas style={{ backgroundColor: '#241249' }}>
   <Story story={BGColor}/>
+</Canvas>
+
+### Opções com tags
+Para usarmos as opções com tags, devemos setar a propriedade **useItemTemplate** para true. E as opções devem conter um array **tabs** como abaixo:
+```
+ options: [
+    { label: 'New York', code: 'NY', tags: [ { label: 'Conteúdos'}, {label: 'Autoavaliações'},{label: 'Sessões de psicoterapia (16)'}, {label: 'Sessões de psiquiatria'}] },
+    { label: 'Rome', code: 'RM', disabled: true },
+    { label: 'London', code: 'LDN' },
+    { label: 'Istanbul', code: 'IST' },
+  ]
+```
+<Canvas>
+  <Story story={Tags}/>
 </Canvas>
 
 ## <a id="api"></a>API

--- a/packages/web/stories/forms/select/select.stories.mdx
+++ b/packages/web/stories/forms/select/select.stories.mdx
@@ -1,40 +1,46 @@
-import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
-import { moduleMetadata } from '@storybook/angular';
-import { FreudSelectComponent, FreudSelectModule } from '@freud-ds/web-components';
-import { FreudHeaderComponent } from '../../header/header.component';
+import { Meta, Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+import { moduleMetadata } from "@storybook/angular";
+import {
+  FreudSelectComponent,
+  FreudSelectModule,
+} from "@freud-ds/web-components";
+import { FreudHeaderComponent } from "../../header/header.component";
 import {
   Default,
   BGColor,
   Disabled,
   Invalid,
   Filter,
-  Tags
-} from './Select.stories.ts';
+  Tags,
+} from "./Select.stories.ts";
 
 <Meta
   decorators={[
     moduleMetadata({
       imports: [FreudSelectModule],
-    })
+    }),
   ]}
   parameters={{
-    layout: 'centered',
+    layout: "centered",
     backgrounds: {
-      default: 'Default',
+      default: "Default",
       values: [
-        { name: 'Default', value: '#FFFFFF' },
-        { name: 'BgColor', value: '#6732D1' },
+        { name: "Default", value: "#FFFFFF" },
+        { name: "BgColor", value: "#6732D1" },
       ],
-    }
+    },
   }}
-title="@freud-ds/web-components/Forms/Select" component={FreudSelectComponent} />
+  title="@freud-ds/web-components/Forms/Select"
+  component={FreudSelectComponent}
+/>
 
 <Story name="Storyname-hidden">
   {{
     component: FreudHeaderComponent,
     props: {
       title: "Select / Dropdown",
-      description: "Uma lista suspensa de itens. Com o item selecionado a exibição é fechada."
+      description:
+        "Uma lista suspensa de itens. Com o item selecionado a exibição é fechada.",
     },
   }}
 </Story>
@@ -42,49 +48,68 @@ title="@freud-ds/web-components/Forms/Select" component={FreudSelectComponent} /
 ## <a id="importing"></a>Import
 
 ```ts
-import { FreudSelectModule } from '@freud-ds/web-components';
+import { FreudSelectModule } from "@freud-ds/web-components";
 ```
 
 ## <a id="exemplos"></a>Exemplos
+
 <br />
 
 ### Default
+
 <Canvas>
-  <Story story={Default}/>
+  <Story story={Default} />
 </Canvas>
 
 ### Filter
+
 <Canvas>
-  <Story story={Filter}/>
+  <Story story={Filter} />
 </Canvas>
 
 ### Invalid
+
 <Canvas>
-  <Story story={Invalid}/>
+  <Story story={Invalid} />
 </Canvas>
 
 ### Disabled
+
 <Canvas>
-  <Story story={Disabled}/>
+  <Story story={Disabled} />
 </Canvas>
 
 ### BG Color
-<Canvas style={{ backgroundColor: '#241249' }}>
-  <Story story={BGColor}/>
+
+<Canvas style={{ backgroundColor: "#241249" }}>
+  <Story story={BGColor} />
 </Canvas>
 
 ### Opções com tags
+
 Para usarmos as opções com tags, devemos setar a propriedade **useItemTemplate** para true. E as opções devem conter um array **tabs** como abaixo:
+
 ```
- options: [
-    { label: 'New York', code: 'NY', tags: [ { label: 'Conteúdos'}, {label: 'Autoavaliações'},{label: 'Sessões de psicoterapia (16)'}, {label: 'Sessões de psiquiatria'}] },
+  options: [
+    {
+      label: 'New York',
+      code: 'NY',
+      tags: [
+        { label: 'Conteúdos'},
+        { label: 'Autoavaliações' },
+        { label: 'Sessões de psicoterapia (16)' },
+        { label: 'Sessões de psiquiatria'},
+      ],
+    },
     { label: 'Rome', code: 'RM', disabled: true },
     { label: 'London', code: 'LDN' },
     { label: 'Istanbul', code: 'IST' },
   ]
+
 ```
+
 <Canvas>
-  <Story story={Tags}/>
+  <Story story={Tags} />
 </Canvas>
 
 ## <a id="api"></a>API


### PR DESCRIPTION
Adição da possibilidade do uso de tags dentro das opções do **freud-select** para a tarefa[ TSAU-2565
](https://zenklub.atlassian.net/browse/TSAU-2565)

![image](https://github.com/Zenklub/freud-ds/assets/45174543/11f2407f-b773-44b9-9d63-c7b5ddfe1e5e)
