### PR TITLE
fix: set default valueOption for select

### DIFF
--- a/packages/web/projects/web-components/src/components/forms/select/select.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/select/select.component.ts
@@ -38,7 +38,7 @@ export class FreudSelectComponent implements ControlValueAccessor {
   @Input() emptyMessage: string = 'Sem resultados';
   @Input() dropdownIcon: string = 'freud-icon freud-icon-chevron-down';
   @Input() optionLabel: string = 'label';
-  @Input() optionValue!: string;
+  @Input() optionValue: string = 'value';
   @Input() optionDisabled: string = 'disabled';
   @Input() optionGroupLabel: string = 'label';
   @Input() optionGroupChildren: string = 'items';


### PR DESCRIPTION
No ultimo [commit ](https://github.com/Zenklub/freud-ds/pull/132), foi adicionado o parâmetro **optionLabel** com o valor "**label**' como default. 

![image](https://github.com/Zenklub/freud-ds/assets/45174543/a47ee3fc-f8c6-4f8c-b092-fe92849101fd)

Porém em alguns casos em que a o **optionValue** não era passado começou a quebrar. ( antes desse commit, caso não passado ele considerava sempre como 'value' ) 

Alguns componentes do office que eram estanciados sem declarar o **optionValue** começaram a emitir o objeto inteiro, causando quebra no que estava implementado. Como no componente abaixo:
![image](https://github.com/Zenklub/freud-ds/assets/45174543/d5b73b5c-85d1-427e-80d6-dc743c1d5d7b)

Apesar de não haver uma indicação direta na documentação do prime ng sobre o **optionLabel** influenciar no **optionValue**, aparentemente estão relacionados. 

Como solução deixei o optionValue setado com o valor 'value' como default.
![image](https://github.com/Zenklub/freud-ds/assets/45174543/48d55355-e296-4715-8238-d451212261db)


