### PR TITLE
TSAU-3604 - Adição de propriedade de erro em inputs

### DIFF
--- a/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.scss
@@ -14,8 +14,11 @@
 }
 
 .freud-input-mask {
-  .help-text {
+  .help-text, .error-text {
     margin-top: $spacing-size-quark;
+  }
+  .error-text {
+    color: $feedback-color-negative-04;
   }
   .freud-field {
     display: flex;

--- a/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.ts
@@ -37,7 +37,13 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
       <small
         [class.disabled]="disabled"
         *ngIf="helpText"
-        class="help-text freud-typography bodyRegularAuto">{{helpText}}</small>
+        class="help-text freud-typography bodyRegularAuto"
+      >{{helpText}}</small>
+      <small
+        [class.disabled]="disabled"
+        *ngIf="errorText"
+        class="error-text freud-typography bodyRegularAuto"
+      >{{errorText}}</small>
     </div>
   `,
   host: {
@@ -55,6 +61,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 export class FreudInputMaskComponent implements ControlValueAccessor {
   @Input() label: string = '';
   @Input() helpText: string = '';
+  @Input() errorText: string = '';
   @Input() placeholder: string = '';
   @Input() invalid: boolean = false;
   @Input() mask: string = '';

--- a/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-mask/input-mask.component.ts
@@ -41,7 +41,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
       >{{helpText}}</small>
       <small
         [class.disabled]="disabled"
-        *ngIf="errorText"
+        *ngIf="invalid && errorText"
         class="error-text freud-typography bodyRegularAuto"
       >{{errorText}}</small>
     </div>

--- a/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.scss
@@ -14,6 +14,10 @@
 }
 
 .freud-input-number {
+  .error-text {
+    color: $feedback-color-negative-04;
+    margin-top: $spacing-size-quark;
+  }
   .freud-field {
     display: flex;
     flex-flow: column;

--- a/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.ts
@@ -56,6 +56,11 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
             (input)="onInput.emit($event)"
             (keydown)="onKeydown.emit($event)"
           ></p-inputNumber>
+          <small
+            [class.disabled]="disabled"
+            *ngIf="errorText"
+            class="error-text freud-typography bodyRegularAuto"
+          >{{errorText}}</small>
     </div>
   `,
   host: {
@@ -73,6 +78,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
 export class FreudInputNumberComponent implements ControlValueAccessor {
   @Input() label: string = '';
+  @Input() errorText: string = '';
   @Input() format: boolean = true;
   @Input() allowEmpty: boolean = true;
   @Input() useGrouping: boolean = true;

--- a/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-number/input-number.component.ts
@@ -58,7 +58,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
           ></p-inputNumber>
           <small
             [class.disabled]="disabled"
-            *ngIf="errorText"
+            *ngIf="invalid && errorText"
             class="error-text freud-typography bodyRegularAuto"
           >{{errorText}}</small>
     </div>

--- a/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.scss
@@ -14,6 +14,10 @@
 }
 
 .freud-input-password {
+  .error-text {
+    color: $feedback-color-negative-04;
+    margin-top: $spacing-size-quark;
+  }
   .freud-field {
     display: flex;
     flex-flow: column;

--- a/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.ts
@@ -47,7 +47,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
         </p-password>
         <small
           [class.disabled]="disabled"
-          *ngIf="errorText"
+          *ngIf="invalid && errorText"
           class="error-text freud-typography bodyRegularAuto"
         >{{errorText}}</small>
     </div>

--- a/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-password/input-password.component.ts
@@ -45,6 +45,11 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
               <ng-content select="[freudTemplatefooter]"></ng-content>
             </ng-template>
         </p-password>
+        <small
+          [class.disabled]="disabled"
+          *ngIf="errorText"
+          class="error-text freud-typography bodyRegularAuto"
+        >{{errorText}}</small>
     </div>
   `,
   host: {
@@ -70,6 +75,7 @@ export class FreudInputPasswordComponent implements ControlValueAccessor {
   @Input() strongLabel!: string;
   @Input() headerLabel!: string;
   @Input() invalid: boolean = false;
+  @Input() errorText: string = '';
   @Input() toggleMask: boolean = true;
   @Input() feedback: boolean = true;
   @Input() bgColor = false;

--- a/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.scss
@@ -14,9 +14,14 @@
 }
 
 .freud-input-text {
-  .help-text {
+  .help-text, .error-text {
     margin-top: $spacing-size-quark;
   }
+
+  .error-text {
+    color: $feedback-color-negative-04;
+  }
+
   .p-input-icon-left>i, .p-input-icon-right>i {
     margin-top: -10px;
     font-size: 24px;

--- a/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.ts
@@ -42,7 +42,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
         >{{helpText}}</small>
 
         <small
-          *ngIf="errorText"
+          *ngIf="invalid && errorText"
           [class.disabled]="disabled"
           class="error-text freud-typography bodyRegularAuto"
         >{{errorText}}</small>

--- a/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-text/input-text.component.ts
@@ -34,8 +34,19 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
             (keydown)="onKeydown.emit($event)"
           />
         </span>
-      <small [class.disabled]="disabled"
-             class="help-text freud-typography bodyRegularAuto">{{helpText ? helpText : ''}}</small>
+
+        <small
+          *ngIf="helpText"
+          [class.disabled]="disabled"
+          class="help-text freud-typography bodyRegularAuto"
+        >{{helpText}}</small>
+
+        <small
+          *ngIf="errorText"
+          [class.disabled]="disabled"
+          class="error-text freud-typography bodyRegularAuto"
+        >{{errorText}}</small>
+      
     </div>
   `,
   host: {
@@ -53,6 +64,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 export class FreudInputTextComponent implements ControlValueAccessor {
   @Input() label: string = '';
   @Input() helpText: string = '';
+  @Input() errorText: string = '';
   @Input() placeholder: string = '';
   @Input() rightIcon!: string;
   @Input() invalid: boolean = false;

--- a/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.scss
+++ b/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.scss
@@ -14,8 +14,11 @@
 }
 
 .freud-input-textarea {
-  .help-text {
+  .help-text, .error-text {
     margin-top: $spacing-size-quark;
+  }
+  .error-text {
+    color: $feedback-color-negative-04;
   }
   .freud-field {
     display: flex;

--- a/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.ts
@@ -42,7 +42,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
         >{{helpText}}</small>
 
         <small
-          *ngIf="errorText"
+          *ngIf="invalid && errorText"
           id="{{id}}-error"
           [class.disabled]="disabled"
           class="error-text freud-typography bodyRegularAuto"

--- a/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.ts
+++ b/packages/web/projects/web-components/src/components/forms/input-textarea/input-textarea.component.ts
@@ -33,9 +33,20 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
           (input)="onInput.emit($event)"
           (keydown)="onKeydown.emit($event)"
         ></textarea>
-      <small id="{{id}}-help"
-             [class.disabled]="disabled"
-             class="help-text freud-typography bodyRegularAuto">{{helpText ? helpText : ''}}</small>
+
+        <small
+          *ngIf="helpText"
+          id="{{id}}-help"
+          [class.disabled]="disabled"
+          class="help-text freud-typography bodyRegularAuto"
+        >{{helpText}}</small>
+
+        <small
+          *ngIf="errorText"
+          id="{{id}}-error"
+          [class.disabled]="disabled"
+          class="error-text freud-typography bodyRegularAuto"
+        >{{errorText}}</small>
     </div>
   `,
   host: {
@@ -53,6 +64,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 export class FreudInputTextAreaComponent implements ControlValueAccessor {
   @Input() label: string = '';
   @Input() helpText: string = '';
+  @Input() errorText: string = '';
   @Input() placeholder: string = '';
   @Input() cols!: number;
   @Input() rows!: number;

--- a/packages/web/stories/forms/input-mask/InputMask.stories.ts
+++ b/packages/web/stories/forms/input-mask/InputMask.stories.ts
@@ -8,6 +8,7 @@ const templateHTML = `
         [label]="label"
         [placeholder]="placeholder"
         [helpText]="helpText"
+        [errorText]="errorText"
         [invalid]="invalid"
         [mask]="mask"
         [bgColor]="bgColor">
@@ -44,6 +45,15 @@ Telefone.args = {
   label: 'Label',
   value: '',
   mask: '(99) 9999-9999'
+};
+
+export const TelefoneError = Template.bind({});
+TelefoneError.args = {
+  label: 'Label',
+  value: '9888',
+  mask: '(99) 9999-9999',
+  invalid: true,
+  errorText: 'Telefone inválido'
 };
 
 export const BGColor = Template.bind({});

--- a/packages/web/stories/forms/input-mask/input-mask.stories.mdx
+++ b/packages/web/stories/forms/input-mask/input-mask.stories.mdx
@@ -7,7 +7,8 @@ import {
   BGColor,
   CPF,
   Celular,
-  Telefone
+  Telefone,
+  TelefoneError,
 } from './InputMask.stories.ts';
 
 <Meta
@@ -84,6 +85,11 @@ Você também pode definir seu próprio padrão regex para caracteres alfa
 ### Telefone
 <Canvas>
   <Story story={Telefone}/>
+</Canvas>
+
+### Telefone Error
+<Canvas>
+  <Story story={TelefoneError}/>
 </Canvas>
 
 ### BG Color

--- a/packages/web/stories/forms/input-number/InputNumber.stories.ts
+++ b/packages/web/stories/forms/input-number/InputNumber.stories.ts
@@ -8,6 +8,7 @@ const templateHTML = `
         [label]="label"
         [placeholder]="placeholder"
         [invalid]="invalid"
+        [errorText]="errorText"
         [showButtons]="showButtons"
         [bgColor]="bgColor">
     </freud-input-number>
@@ -75,3 +76,10 @@ Invalid.args = {
   invalid: true,
 };
 
+export const ErrorText = Template.bind({});
+ErrorText.args = {
+  label: 'Label',
+  placeholder: 'Placeholder',
+  invalid: true,
+  errorText: 'Error Text',
+};

--- a/packages/web/stories/forms/input-number/input-number.stories.mdx
+++ b/packages/web/stories/forms/input-number/input-number.stories.mdx
@@ -7,7 +7,8 @@ import {
   BGColor,
   Disabled,
   ButtonLayout,
-  Invalid
+  Invalid,
+  ErrorText
 } from './InputNumber.stories.ts';
 
 <Meta
@@ -55,6 +56,11 @@ import { FreudInputNumberModule } from '@freud-ds/web-components';
 ### Invalid
 <Canvas>
   <Story story={Invalid}/>
+</Canvas>
+
+### ErrorText
+<Canvas>
+  <Story story={ErrorText}/>
 </Canvas>
 
 ### Disabled

--- a/packages/web/stories/forms/input-password/InputPassword.stories.ts
+++ b/packages/web/stories/forms/input-password/InputPassword.stories.ts
@@ -55,6 +55,7 @@ const templateHTML = `
         [feedback]="feedback"
         [placeholder]="placeholder"
         [invalid]="invalid"
+        [errorText]="errorText"
         [bgColor]="bgColor">
     </freud-input-password>
 `;
@@ -99,6 +100,15 @@ Invalid.args = {
   label: 'Label',
   placeholder: 'Placeholder',
   invalid: true,
+  feedback: false,
+};
+
+export const ErrorText = Template.bind({});
+ErrorText.args = {
+  label: 'Label',
+  placeholder: 'Placeholder',
+  invalid: true,
+  errorText: 'Senha inválida',
   feedback: false,
 };
 

--- a/packages/web/stories/forms/input-password/input-password.stories.mdx
+++ b/packages/web/stories/forms/input-password/input-password.stories.mdx
@@ -7,6 +7,7 @@ import {
   BGColor,
   Feedback,
   Invalid,
+  ErrorText,
   CustomTemplate
 } from './InputPassword.stories.ts';
 
@@ -105,6 +106,11 @@ O componente de senha usa expressões regulares para senhas médias e fortes com
 ### Invalid
 <Canvas>
   <Story story={Invalid}/>
+</Canvas>
+
+### ErrorText
+<Canvas>
+  <Story story={ErrorText}/>
 </Canvas>
 
 ### Feedback

--- a/packages/web/stories/forms/input-text/InputText.stories.ts
+++ b/packages/web/stories/forms/input-text/InputText.stories.ts
@@ -8,6 +8,7 @@ const templateHTML = `
         [label]="label"
         [placeholder]="placeholder"
         [helpText]="helpText"
+        [errorText]="errorText"
         [invalid]="invalid"
         [rightIcon]="rightIcon"
         [bgColor]="bgColor">
@@ -45,7 +46,12 @@ HelperText.args = {
   helpText: 'Helper Text',
 };
 
-
+export const ErrorText = Template.bind({});
+ErrorText.args = {
+  label: 'Label',
+  placeholder: 'Placeholder',
+  errorText: 'Error Text',
+};
 
 export const BGColor = Template.bind({});
 BGColor.args = {
@@ -53,6 +59,7 @@ BGColor.args = {
   placeholder: 'Placeholder',
   bgColor: true,
   helpText: 'Helper Text',
+  errorText: 'Error Text',
 };
 export const Disabled = Template.bind({});
 Disabled.args = {

--- a/packages/web/stories/forms/input-text/InputText.stories.ts
+++ b/packages/web/stories/forms/input-text/InputText.stories.ts
@@ -50,6 +50,7 @@ export const ErrorText = Template.bind({});
 ErrorText.args = {
   label: 'Label',
   placeholder: 'Placeholder',
+  invalid: true,
   errorText: 'Error Text',
 };
 
@@ -59,6 +60,7 @@ BGColor.args = {
   placeholder: 'Placeholder',
   bgColor: true,
   helpText: 'Helper Text',
+  invalid: true,
   errorText: 'Error Text',
 };
 export const Disabled = Template.bind({});

--- a/packages/web/stories/forms/input-text/input-text.stories.mdx
+++ b/packages/web/stories/forms/input-text/input-text.stories.mdx
@@ -7,7 +7,10 @@ import {
   BGColor,
   Disabled,
   Placeholder,
-  Icon, Invalid, HelperText
+  Icon,
+  Invalid,
+  HelperText,
+  ErrorText,
 } from './InputText.stories.ts';
 
 <Meta
@@ -75,6 +78,11 @@ import { FreudInputTextModule } from '@freud-ds/web-components';
 ### Helper Text
 <Canvas>
   <Story story={HelperText}/>
+</Canvas>
+
+### Error Text
+<Canvas>
+  <Story story={ErrorText}/>
 </Canvas>
 
 ### BG Color

--- a/packages/web/stories/forms/input-textarea/InputTextArea.stories.ts
+++ b/packages/web/stories/forms/input-textarea/InputTextArea.stories.ts
@@ -12,6 +12,7 @@ const templateHTML = `
         [placeholder]="placeholder"
         [helpText]="helpText"
         [invalid]="invalid"
+        [errorText]="errorText"
         [bgColor]="bgColor">
     </freud-input-textarea>
 `;
@@ -55,5 +56,13 @@ Invalid.args = {
   label: 'Label',
   placeholder: 'Placeholder',
   invalid: true,
+};
+
+export const ErrorText = Template.bind({});
+ErrorText.args = {
+  label: 'Label',
+  placeholder: 'Placeholder',
+  invalid: true,
+  errorText: 'Error Text',
 };
 

--- a/packages/web/stories/forms/input-textarea/input-textarea.stories.mdx
+++ b/packages/web/stories/forms/input-textarea/input-textarea.stories.mdx
@@ -6,7 +6,9 @@ import {
   Default,
   BGColor,
   Disabled,
-  Invalid, AutoResize
+  Invalid,
+  ErrorText,
+  AutoResize
 } from './InputTextArea.stories.ts';
 
 <Meta
@@ -54,6 +56,11 @@ import { FreudInputTextAreaModule } from '@freud-ds/web-components';
 ### Invalid
 <Canvas>
   <Story story={Invalid}/>
+</Canvas>
+
+### ErrorText
+<Canvas>
+  <Story story={ErrorText}/>
 </Canvas>
 
 ### Disabled


### PR DESCRIPTION
Card: https://conexasaude.atlassian.net/browse/TSAU-3604

Implementação: Adicionada propriedade `errorText` nos componentes de input, para o erro ser renderizado é necessário que a propriedade `invalid` tenha o valor `true`